### PR TITLE
fix(.gitmodules): make geonature submodule url generic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dependencies/GeoNature"]
 	path = dependencies/GeoNature
-	url = git@github.com:PnX-SI/GeoNature.git
+	url = ../GeoNature.git


### PR DESCRIPTION
Allows `GeoNature` submodule URL protocol to be consistent with protocol used for remote of root repository `mtd_sync`: Git SSH, HTTPS.